### PR TITLE
Use feathers errors

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1,6 +1,6 @@
 var Proto = require('uberproto');
 var mongo = require('mongoskin');
-var errors = require('feathers').errors.types;
+var errors = require('feathers-errors').types;
 var _ = require('lodash');
 
 var MongoService = Proto.extend({

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "body-parser": "^1.4.3",
     "chai": "^1.7.2",
     "database-cleaner": "~0.7.0",
+    "feathers": ">= 1.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "~0.1.7",
     "grunt-contrib-jshint": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -32,16 +32,13 @@
   "dependencies": {
     "lodash": "~2.4.1",
     "mongoskin": "^0.6.1",
-    "uberproto": "~1.1.0"
-  },
-  "peerDependencies": {
-    "feathers": ">= 1.0.0-pre.1"
+    "uberproto": "~1.1.0",
+    "feathers-errors": ">=0.2.0"
   },
   "devDependencies": {
     "body-parser": "^1.4.3",
     "chai": "^1.7.2",
     "database-cleaner": "~0.7.0",
-    "feathers": ">= 1.0.0-pre.1",
     "grunt": "^0.4.5",
     "grunt-cli": "~0.1.7",
     "grunt-contrib-jshint": "^0.10.0",


### PR DESCRIPTION
As mentioned in #9, instead of bringing in all of feathers just to work with errors, this brings in feathers-errors and removes 'feathers' as a dependency.