### PR TITLE
Plugin consistency

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+languages:
+  JavaScript: true
+# exclude_paths:
+# - "foo/bar.rb"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# === Node ===
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+pids
+logs
+results
+
+npm-debug.log
+node_modules
+
+# === Mac ===
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must ends with two \r.
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# === Vim ===
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+# === Sublime ===
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project
+
+# === Webstorm ===
+.idea

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,4 @@
 {
-  "expr": true,
   "node": true,
   "esnext": true,
   "bitwise": true,
@@ -9,7 +8,7 @@
   "immed": true,
   "indent": 2,
   "latedef": "nofunc",
-  "newcap": false,
+  "newcap": true,
   "noarg": true,
   "quotmark": "single",
   "regexp": true,
@@ -19,13 +18,15 @@
   "trailing": true,
   "smarttabs": true,
   "white": false,
+  "loopfunc": true,
+  "expr": true,
   "globals": {
     "it": true,
     "describe": true,
     "before": true,
-    "after": true,
-    "exports": true,
     "beforeEach": true,
-    "afterEach": true
+    "after": true,
+    "afterEach": true,
+    "exports": true
   }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 YYC.js
+Copyright (c) 2015 FeathersJS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ The following options can be passed when creating a new MongoDB service:
 
 - `connectionString` - A MongoDB connection string
 - `_id` - The id property (default: `"_id"`)
-- `username` - MongoDB username
-- `password` - MongoDB password
 
 **Connection options:** (when `connectionString` is not set)
 
 - `db` - The name of the database (default: `"feathers"`) 
 - `host` - The MongoDB host (default: `"localhost"`) 
-- `port` - The MongoDB port (default: `27017`) 
+- `port` - The MongoDB port (default: `27017`)
+- `username` - MongoDB username
+- `password` - MongoDB password
+- `reconnect` - Whether the connection should automatically reconnect (default: `true`)
 
 **MongoDB options:**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 feathers-mongodb
 ================
 
+[![NPM](https://nodei.co/npm/feathers-mongodb.png?downloads=true&stars=true)](https://nodei.co/npm/feathers-mongodb/)
+
 [![Build Status](https://travis-ci.org/feathersjs/feathers-mongodb.png?branch=master)](https://travis-ci.org/feathersjs/feathers-mongodb)
 [![Code Climate](https://codeclimate.com/github/feathersjs/feathers-mongodb.png)](https://codeclimate.com/github/feathersjs/feathers-mongodb)
 
-A MongoDB CRUD service for [feathers](http://feathersjs.com)
+> Create a MongoDB service for [FeathersJS](http://feathersjs.com)
 
 ## Getting Started
 
@@ -14,45 +16,71 @@ To install feathers-hooks from [npm](https://www.npmjs.org/), run:
 $ npm install feathers-mongodb --save
 ```
 
-Finally, to use the plugin in your Feathers app:
+Creating an MongoDB service is this simple:
 
-```javascript
-var feathers = require('feathers');
-var mongodb = require('feathers-mongodb');
-
-// Initialize a MongoDB service with the users collection on a local MongoDB instance
-var app = feathers()
-  .use('/users', mongodb({
-    collection: 'users'
-  }));
-  
-app.listen(8080);
+```js
+var mongoService = require('feathers-mongodb');
+app.use('todos', mongoService('todos', options));
 ```
+
+### Complete Example
+
+Here's a complete example of a Feathers server with a `todos` mongodb-service.
+
+```js
+// server.js
+var feathers = require('feathers'),
+  bodyParser = require('body-parser'),
+  mongoService = require('feathers-mongo');
+
+// Create a feathers instance.
+var app = feathers()
+  // Setup the public folder.
+  .use(feathers.static(__dirname + '/public'))
+  // Enable Socket.io
+  .configure(feathers.socketio())
+  // Enable REST services
+  .configure(feathers.rest())
+  // Turn on JSON parser for REST services
+  .use(bodyParser.json())
+  // Turn on URL-encoded parser for REST services
+  .use(bodyParser.urlencoded({extended: true}))
+
+// Connect to the db, create and register a Feathers service.
+app.use('todos', new mongoService('todos'));
+
+// Start the server.
+var port = 8080;
+app.listen(port, function() {
+    console.log('Feathers server listening on port ' + port);
+});
+```
+
+You can run this example by using `node examples/basic` and going to [localhost:8080/todos](http://localhost:8080/todos). You should see an empty array. That's because you don't have any Todos yet but you now have full CRUD for your new todos service!
 
 ## Options
 
 The following options can be passed when creating a new MongoDB service:
 
-General options:
+**General options:**
 
-- `collection` - The name of the collection or an already-connected collection object.  When using an object, no other options are needed.  See the example below.
 - `connectionString` - A MongoDB connection string
-- `[_id]` (default: `"_id"`) - The id property
+- `_id` - The id property (default: `"_id"`)
 - `username` - MongoDB username
 - `password` - MongoDB password
 
-Connection options (when `connectionString` is not set):
+**Connection options:** (when `connectionString` is not set)
 
-- `db` (default: `"feathers"`) - The name of the database
-- `host` (default: `"localhost"`) - The MongoDB host
-- `port` (default: `27017`) - The MongoDB port
+- `db` - The name of the database (default: `"feathers"`) 
+- `host` - The MongoDB host (default: `"localhost"`) 
+- `port` - The MongoDB port (default: `27017`) 
 
-MongoDB options:
+**MongoDB options:**
 
-- `w` (default: `1`) - Write acknowledgements
-- `journal` (default: `false`) - Don't wait for journal before acknowledgement
-- `fsync` (default: `false`) - Don't wait for syncing to disk before acknowledgment
-- `safe` (default: `false`) - Safe mode 
+- `w` - Write acknowledgments (default: `1`) 
+- `journal` - Don't wait for journal before acknowledgment (default: `false`) 
+- `fsync` - Don't wait for syncing to disk before acknowledgment (default: `false`) 
+- `safe` - Safe mode (default: `false`)
 
 ## Sharing a MongoDB connection between services
 When creating a new service, the default behavior is to create a new connection to the specified database.  If you would rather share a database connection between multiple services, connect to the database then pass an already-connected collection object in on options.collection.  For example:
@@ -125,7 +153,7 @@ module.exports.Service = TimestampPatchService;
 
 Another option is to weave functionality into your existing services using [feathers-hooks](https://github.com/feathersjs/feathers-hooks), for example the above `createdAt` and `updatedAt` functionality:
 
-```javascript
+```js
 var feathers = require('feathers');
 var hooks = require('feathers-hooks');
 var mongodb = require('feathers-mongodb');
@@ -135,7 +163,7 @@ var app = feathers()
   .configure(hooks())
   .use('/users', mongodb({
     collection: 'users'
-  });
+  }));
   
 app.lookup('users').before({
   create: function(hook, next) {
@@ -152,56 +180,107 @@ app.lookup('users').before({
 app.listen(8080);
 ```
 
-## MongoDB options and filtering
-
-Internally the MongoDB service uses [MongoSkin](https://github.com/kissjs/node-mongoskin).
-The query options (e.g. for a `.find`) call are taken from `params.query`.
-To set the query options, set `params.options` in your service calls. Using [feathers-hooks](https://github.com/feathersjs/feathers-hooks), for example, a sort mechanism based on query parameters
-(e.g. `/users?__sort=name`) can be implemented as a hook like this:
+## Special Query Params
+The `find` API allows the use of `$limit`, `$skip`, `$sort`, and `$select` in the query.  These special parameters can be passed directly inside the query object:
 
 ```js
-var app = feathers()
-  .configure(hooks())
-  .use('/users', mongodb({
-    collection: 'users'
-  });
-  
-app.lookup('users').before({
-  find: function(hook, next) {
-    // Grab the fieldname from `params.query`
-    var field = hook.params.query.__sort;
-    if(field) {
-      hook.params.options = { sort: [[field, -1]] };
-    }
-    // Delete it from the query so that it's not passed as
-    // the MongoSkin query object
-    delete hook.params.query.__sort;
-    
-    next();
-  }
-});
+// Find all recipes that include salt, limit to 10, only include name field.
+{"ingredients":"salt", "$limit":10, "$select":"name:1"} // JSON
+GET /?ingredients=salt&%24limit=10&%24select=name%3A1 // HTTP
+```
+
+As a result of allowing these to be put directly into the query string, you won't want to use `$limit`, `$skip`, `$sort`, or `$select` as the name of fields in your document schema.
+
+### `$limit`
+
+`$limit` will return only the number of results you specify:
+
+```
+// Retrieves the first two records found where age is 37.
+query: {
+  age: 37,
+  $limit: 2
+}
 ```
 
 
+### `$skip`
+
+`$skip` will skip the specified number of results:
+
+```
+// Retrieves all except the first two records found where age is 37.
+query: {
+  age: 37,
+  $skip: 2
+}
+```
+
+
+### `$sort`
+
+`$sort` will sort based on the object you provide:
+
+```
+// Retrieves all where age is 37, sorted ascending alphabetically by name.
+query: {
+  age: 37,
+  $sort: {'name': 1}
+}
+
+// Retrieves all where age is 37, sorted descending alphabetically by name.
+query: {
+  age: 37,
+  $sort: {'name': -1}
+}
+```
+
+
+### `$select`
+`$select` support in a query allows you to pick which fields to include or exclude in the results.  Note: you can use the include syntax or the exclude syntax, not both together.  See the section on [`Select`](http://mongoosejs.com/docs/api.html#query_Query-select) in the Mongoose docs.
+```
+// Only retrieve name.
+query: {
+  name: 'Alice',
+  $select: {'name': 1}
+}
+
+// Retrieve everything except age.
+query: {
+  name: 'Alice',
+  $select: {'age': 0}
+}
+```
+
+## API
+
+`feathers-mongodb` services comply with the standard [FeathersJS API](http://feathersjs.com/docs).
+
 ## Changelog
 
-__0.3.0__
+### 1.0.0
+- Compatibility with feathers 1.x
+- Add special query params:
+    - $sort
+    - $skip
+    - $limit
+    - $select
+
+### 0.3.0
 
 - Implement `.patch` support ([#5](https://github.com/feathersjs/feathers-mongodb/issues/5))
 - Better documentation
 - Refactoring that removes pre-implemented MongoSkin options
 
-__0.2.x__
+### 0.2.x
 
 - Pre-releases
+
+## License
+
+[MIT](LICENSE)
 
 ## Authors
 
 - [Eric Kryski](https://github.com/ekryski)
 - [David Luecke](https://github.com/daffl)
-
-## License
-
-Copyright (c) 2014 Eric Kryski, David Luecke
-
-Licensed under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -260,12 +260,14 @@ query: {
 ## Changelog
 
 ### 1.0.0
-- Compatibility with feathers 1.x
-- Add special query params:
+- makes this adapter consistent with the others in terms of documentation and file structure
+- updates mongoskin dependency to the latest
+- adds support for special query filters
     - $sort
+    - $select
     - $skip
     - $limit
-    - $select
+- Closes #8 by making sure that we autoreconnect by default when not passing a connection string
 
 ### 0.3.0
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,14 +1,25 @@
-var feathers = require('feathers');
-var mongodb = require('../lib/mongodb');
-var bodyParser = require('body-parser');
-var app = feathers();
+var feathers = require('feathers'),
+  bodyParser = require('body-parser'),
+  mongoService = require('../lib/feathers-mongodb');
 
-var userService = mongodb({ collection: 'users' });
+// Create a feathers instance.
+var app = feathers()
+  // Setup the public folder.
+  .use(feathers.static(__dirname + '/public'))
+  // Enable Socket.io
+  .configure(feathers.socketio())
+  // Enable REST services
+  .configure(feathers.rest())
+  // Turn on JSON parser for REST services
+  .use(bodyParser.json())
+  // Turn on URL-encoded parser for REST services
+  .use(bodyParser.urlencoded({extended: true}))
 
-app.configure(feathers.rest())
-   .use(bodyParser.json())
-   .use('/users', userService)
-   .configure(feathers.errors())
-   .listen(8080);
+// Connect to the db, create and register a Feathers service.
+app.use('todos', new mongoService('todos'));
 
-console.log('App listening on 127.0.0.1:8080');
+// Start the server.
+var port = 8080;
+app.listen(port, function() {
+    console.log('Feathers server listening on port ' + port);
+});

--- a/lib/feathers-mongodb.js
+++ b/lib/feathers-mongodb.js
@@ -7,9 +7,14 @@ var _ = require('lodash');
 var MongoService = Proto.extend({
   // TODO (EK): How do we handle indexes?
   init: function(collection, options) {
+    if (_.isObject(collection)) {
+      options = collection;
+      collection = options.collection;
+    }
+
     options = options || {};
 
-    if(!collection) {
+    if (!collection) {
       throw new errors.GeneralError('No MongoDB collection name specified.');
     }
 

--- a/lib/feathers-mongodb.js
+++ b/lib/feathers-mongodb.js
@@ -47,18 +47,21 @@ var MongoService = Proto.extend({
       var config = _.extend({
         host: 'localhost',
         port: 27017,
-        db: 'feathers'
+        db: 'feathers',
+        reconnect: true
       }, options);
 
-      connectionString = 'mongodb://' + config.host + ':' + config.port + '/' + config.db;
-    }
+      connectionString = 'mongodb://';
 
-    if (options.username && options.password) {
-      connectionString += options.username + ':' + options.password + '@';
-    }
+      if (config.username && config.password) {
+        connectionString += config.username + ':' + config.password + '@';
+      }
 
-    if (options.reconnect) {
-      connectionString += '?auto_reconnect=true';
+      connectionString += config.host + ':' + config.port + '/' + config.db;
+
+      if (config.reconnect) {
+        connectionString += '?auto_reconnect=true';
+      }
     }
 
     this.store = mongo.db(connectionString, ackOptions);

--- a/lib/feathers-mongodb.js
+++ b/lib/feathers-mongodb.js
@@ -1,14 +1,15 @@
 var Proto = require('uberproto');
 var mongo = require('mongoskin');
 var errors = require('feathers').errors.types;
+var filter = require('feathers-query-filters');
 var _ = require('lodash');
 
 var MongoService = Proto.extend({
   // TODO (EK): How do we handle indexes?
-  init: function(options) {
+  init: function(collection, options) {
     options = options || {};
 
-    if(!options.collection) {
+    if(!collection) {
       throw new errors.GeneralError('No MongoDB collection name specified.');
     }
 
@@ -18,42 +19,44 @@ var MongoService = Proto.extend({
     }, options);
 
     this._connect(this.options);
+    this.collection = this.store.collection(collection);
   },
 
   // TODO (EK): We need to handle replica sets.
   _connect: function(options) {
-    if (typeof options.collection === 'string') {
-      var connectionString = options.connectionString;
-      var ackOptions = {
-        w: options.w || 1,                  // write acknowledgment
-        journal: options.journal || false,  // doesn't wait for journal before acknowledgment
-        fsync: options.fsync || false,       // doesn't wait for syncing to disk before acknowledgment
-        safe: options.safe || false
-      };
-
-      if(!connectionString) {
-        var config = _.extend({
-          host: 'localhost',
-          port: 27017,
-          db: 'feathers'
-        }, options);
-
-        connectionString = config.host + ':' + config.port + '/' + config.db;
-      }
-
-      if(options.username && options.password) {
-        connectionString += options.username + ':' + options.password + '@';
-      }
-
-      if(options.reconnect) {
-        connectionString += '?auto_reconnect=true';
-      }
-
-      this.store = mongo.db(connectionString, ackOptions);
-      this.collection = this.store.collection(options.collection);
-    } else {
-      this.collection = options.collection;
+    // If we are passing an existing connection we'll use that.
+    if (options.connection) {
+      this.store = options.connection;
+      return;
     }
+    
+    var connectionString = options.connectionString;
+    var ackOptions = {
+      w: options.w || 1,                  // write acknowledgment
+      journal: options.journal || false,  // doesn't wait for journal before acknowledgment
+      fsync: options.fsync || false,       // doesn't wait for syncing to disk before acknowledgment
+      safe: options.safe || false
+    };
+
+    if (!connectionString) {
+      var config = _.extend({
+        host: 'localhost',
+        port: 27017,
+        db: 'feathers'
+      }, options);
+
+      connectionString = 'mongodb://' + config.host + ':' + config.port + '/' + config.db;
+    }
+
+    if (options.username && options.password) {
+      connectionString += options.username + ':' + options.password + '@';
+    }
+
+    if (options.reconnect) {
+      connectionString += '?auto_reconnect=true';
+    }
+
+    this.store = mongo.db(connectionString, ackOptions);
   },
 
   find: function(params, cb) {
@@ -62,7 +65,31 @@ var MongoService = Proto.extend({
       params = {};
     }
 
-    this.collection.find(params.query || {}, params.options || {}).toArray(cb);
+    params.query = params.query || {};
+    var options = params.options || {};
+    var filters = filter(params.query);
+
+    if (filters.$select && filters.$select.length) {
+      options.fields = {};
+      
+      _.each(filters.$select, function(key){
+        options.fields[key] = 1;
+      });
+    }
+
+    if (filters.$sort){
+      options.sort = filters.$sort;
+    }
+
+    if (filters.$limit){
+      options.limit = filters.$limit;
+    }
+
+    if (filters.$skip){
+      options.skip = filters.$skip;
+    }
+
+    this.collection.find(params.query, options).toArray(cb);
   },
 
   get: function(id, params, cb) {

--- a/package.json
+++ b/package.json
@@ -2,15 +2,25 @@
   "name": "feathers-mongodb",
   "description": "Feathers MongoDB service",
   "version": "0.3.2",
-  "homepage": "https://feathersjs.com",
+  "homepage": "https://github.com/feathersjs/feathers-mongodb",
   "repository": {
     "type": "git",
     "url": "git://github.com/feathersjs/feathers-mongodb.git"
   },
+  "bugs": {
+    "url": "https://github.com/feathersjs/feathers-mongodb/issues"
+  },
+  "license": "MIT",
   "keywords": [
-    "services",
     "feathers",
-    "mongodb"
+    "feathers-plugin",
+    "REST",
+    "Socket.io",
+    "realtime",
+    "mongo",
+    "mongoskin",
+    "mongodb",
+    "service"
   ],
   "author": "Feathers <hello@feathersjs.com> (http://feathersjs.com)",
   "contributors": [
@@ -18,11 +28,7 @@
     "David Luecke <daff@neyeon.de> (http://neyeon.com)",
     "Marshall Thompson <marshall@creativeideal.net>"
   ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/feathersjs/feathers-mongodb/issues"
-  },
-  "main": "lib/mongodb.js",
+  "main": "lib/feathers-mongodb.js",
   "scripts": {
     "publish": "git push origin --tags",
     "release:patch": "npm version patch && npm publish",
@@ -37,18 +43,18 @@
     "npm": "~1.4.0"
   },
   "dependencies": {
-    "lodash": "~2.4.1",
-    "mongoskin": "^0.6.1",
-    "uberproto": "~1.1.0"
+    "feathers-query-filters": "^1.1.1",
+    "lodash": "^3.10.0",
+    "mongodb": "^1.4.39",
+    "mongoskin": "^1.4.13",
+    "uberproto": "~1.1.2"
   },
   "devDependencies": {
     "body-parser": "^1.4.3",
     "chai": "^1.7.2",
     "database-cleaner": "~0.7.0",
-    "feathers": "^1.0.0",
+    "feathers": "^1.1.0",
     "jshint": "^2.7.0",
-    "mocha": "^1.12.1",
-    "sinon": "^1.7.3",
-    "sinon-chai": "^2.4.0"
+    "mocha": "^1.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feathers-mongodb",
   "description": "Feathers MongoDB service",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "homepage": "https://github.com/feathersjs/feathers-mongodb",
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -40,17 +40,41 @@ describe('Feathers MongoDB Service', function() {
   });
 
   describe('init', function() {
-    it('sets up a mongo connection based on config', function(done) {
-      var myService = mongodb('other-test', {
-        db: 'some-database'
+    describe('with collection', function() {
+      it('throws an error', function() {
+        expect(mongodb).to.throw('No MongoDB collection name specified.');
+      });
+    });
+
+    describe('with collection', function() {
+      it('sets up a mongo connection collection string', function(done) {
+        var myService = mongodb('other-test', {
+          db: 'some-database'
+        });
+
+        myService.create({ name: 'David' }, function(error, data) {
+          expect(error).to.be.null;
+          expect(data._id).to.be.ok;
+          databaseCleaner.clean(myService.store, function() {
+            myService.store.close();
+            done();
+          });
+        });
       });
 
-      myService.create({ name: 'David' }, function(error, data) {
-        expect(error).to.be.null;
-        expect(data._id).to.be.ok;
-        databaseCleaner.clean(myService.store, function() {
-          myService.store.close();
-          done();
+      it('sets up a mongo connection based on config', function(done) {
+        var myService = mongodb({
+          db: 'some-database',
+          collection: 'other-test'
+        });
+
+        myService.create({ name: 'David' }, function(error, data) {
+          expect(error).to.be.null;
+          expect(data._id).to.be.ok;
+          databaseCleaner.clean(myService.store, function() {
+            myService.store.close();
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
This PR:
- makes this adapter consistent with the others in terms of documentation and file structure
- updates mongoskin dependency to the latest
- adds support for special query filters
    - $sort
    - $select
    - $skip
    - $limit
- Closes #8 by making sure that we autoreconnect by default when not passing a connection string

In order to be consistent with other adapters we now specify the collection like so:

```js
app.use('todos', mongoService('todos', options));
```

I've maintained the ability to pass it via options `{collection: 'todos'}` so as not to break backwords compatibility.