### PR TITLE
Always set "id" field during PUT updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,8 +131,8 @@ class Service {
 
     let { query, options } = multiOptions(id, params, this.id);
 
-    // We can not update the id
-    delete data[this.id];
+    // We can not update the id, but it must be set to its previous value
+    data[this.id] = id;
 
     return this.Model
         .update(query, data, options)

--- a/src/index.js
+++ b/src/index.js
@@ -131,8 +131,13 @@ class Service {
 
     let { query, options } = multiOptions(id, params, this.id);
 
-    // We can not update the id, but it must be set to its previous value
-    data[this.id] = id;
+    if (this.id === '_id') {
+      // We can not update the id
+      delete data[this.id];
+    } else {
+      // If not using the default Mongo _id field, the id must be set to its previous value
+      data[this.id] = id;
+    }
 
     return this.Model
         .update(query, data, options)


### PR DESCRIPTION
When performing a `PUT` update action, the `id` field must be set. Otherwise, the object loses this field and becomes an orphan.

I did not write a test, because this seems like the sort that should go into https://github.com/feathersjs/feathers-service-tests.

Fixes #25.