### PR TITLE
Add support for MongoDB collation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ node_js:
 addons:
   code_climate:
     repo_token: db77b58022717b6f1287d1af327a41a58064dfd0b80cf37ecb5e67a866607c83
+  apt:
+    sources:
+    - sourceline: 'deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
+    packages:
+    - mongodb-org-server
 before_script:
   - 'npm install -g codeclimate-test-reporter'
 after_script:

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,10 @@ class Service {
       q.sort(filters.$sort);
     }
 
+    if (params.collation) {
+      q.collation(params.collation);
+    }
+
     if (filters.$limit) {
       q.limit(filters.$limit);
     }
@@ -183,7 +187,7 @@ class Service {
   }
 
   patch (id, data, params) {
-    const { query, options } = this._multiOptions(id, params);
+    let { query, options } = this._multiOptions(id, params);
     const mapIds = page => page.data.map(current => current[this.id]);
 
     // By default we will just query for the one id. For multi patch
@@ -191,6 +195,10 @@ class Service {
     // to re-query them after the update
     const ids = id === null ? this._find(params)
         .then(mapIds) : Promise.resolve([ id ]);
+
+    if (params.collation) {
+      query = Object.assign(query, { collation: params.collation });
+    }
 
     // Run the query
     return ids
@@ -227,6 +235,10 @@ class Service {
 
   remove (id, params) {
     let { query, options } = this._multiOptions(id, params);
+
+    if (params.collation) {
+      query = Object.assign(query, { collation: params.collation });
+    }
 
     return this._findOrGet(id, params)
       .then(items => this.Model

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,4 +138,91 @@ describe('Feathers MongoDB Service', () => {
       });
     });
   });
+
+  describe('Special collation param', () => {
+    let peopleService;
+
+    function indexOfName (results, name) {
+      let index;
+      results.every(function (person, i) {
+        if (person.name === name) {
+          index = i;
+          return false;
+        }
+        return true;
+      });
+      return index;
+    }
+
+    beforeEach(() => {
+      peopleService = app.service('/people');
+
+      return peopleService.remove(null, {}).then(() => {
+        return peopleService.create([
+          {name: 'AAA'},
+          {name: 'aaa'},
+          {name: 'ccc'}
+        ]);
+      });
+    });
+
+    it('sorts with default behavior without collation param', () => {
+      return peopleService
+        .find({ query: { $sort: {name: -1} } })
+        .then(r => {
+          expect(indexOfName(r, 'aaa')).to.be.below(indexOfName(r, 'AAA'));
+        });
+    });
+
+    it('sorts using collation param if present', () => {
+      return peopleService
+        .find({ query: { $sort: {name: -1} }, collation: {locale: 'en', strength: 1} })
+        .then(r => {
+          expect(indexOfName(r, 'AAA')).to.be.below(indexOfName(r, 'aaa'));
+        });
+    });
+
+    it('removes with default behavior without collation param', () => {
+      return peopleService
+        .remove(null, { query: { name: { $gt: 'AAA' } } })
+        .then(() => {
+          return peopleService.find().then((r) => {
+            expect(r).to.have.lengthOf(1);
+            expect(r[0].name).to.equal('AAA');
+          });
+        });
+    });
+
+    it('removes using collation param if present', () => {
+      return peopleService
+        .remove(null, { query: { name: { $gt: 'AAA' } }, collation: {locale: 'en', strength: 1} })
+        .then(() => {
+          return peopleService.find().then((r) => {
+            expect(r).to.have.lengthOf(3);
+          });
+        });
+    });
+
+    it('updates with default behavior without collation param', () => {
+      const query = { name: { $gt: 'AAA' } };
+
+      return peopleService
+        .patch(null, {age: 99}, { query })
+        .then(r => {
+          expect(r).to.have.lengthOf(2);
+          r.forEach(person => {
+            expect(person.age).to.equal(99);
+          });
+        });
+    });
+
+    it('updates using collation param if present', () => {
+      return peopleService
+        .patch(null, {age: 110}, { query: { name: { $gt: 'AAA' } }, collation: {locale: 'en', strength: 1} })
+        .then(r => {
+          expect(r).to.have.lengthOf(1);
+          expect(r[0].name).to.equal('ccc');
+        });
+    });
+  });
 });


### PR DESCRIPTION
This PR adds MongoDB collation support to the `find`, `remove` and `patch` methods. Using collations, it's possible to perform case-insensitive and locale-aware queries.

**I'm not sure what the built-in version of MongoDB is on Travis CI. This PR will likely fail to build if using < v3.4. See Potential Problems below.** 

MongoDB introduced collation support in v3.4 see the [Release Notes for MongoDB 3.4 – Collation and Case Insensitive Indexes](https://docs.mongodb.com/manual/release-notes/3.4/#collation-and-case-insensitive-indexes) for more information on the feature.

This pull request implements collation support via a `collation` parameter passed to `find()`, `remove()` and `patch()`. Tests are included in this PR, but here are some quick examples on how this could be used:

## Example: Patch records with case-insensitive alphabetical ordering.
The example below would patch all student records with grades of `"c"` or `"C"` and above (a natural language ordering). Without collations this would not be as simple, since the comparison `{ $gt: "c" }` would not include uppercase grades of `"C"` because the binary codepoint of `"C"` is less than `"c"`.
```
const patch = { shouldStudyMore: true };
const query = { grade: { $gte: "c" } };
const collation = { locale: "en", strength: 1 };
students.patch(null, patch, { query, collation }).then( ... );
```

## Example: Find records with a case-insensitive search.
Similar to the above example, this would find poor students by their grades, in a case-insensitive manner.
```
const query = { grade: { $gte: "c" } };
const collation = { locale: "en", strength: 1 };
students.find({ query, collation }).then( ... );
```

## Potential Problems
One potential problem I see with the `update()` method, is that a `collation` member must be added to the query passed to MongoDB. [MongoDB's documentation on this](https://docs.mongodb.com/manual/reference/method/db.collection.update/) is a little vague... it seems that you would set the `collation` member on the `option` parameter, but that does not work. This could lead to a collision when updating records with a `collation` member. I'm open to suggestions on how to solve this. Since MongoDB v3.4 is so young, there's not a lot of discourse available on the best way to uses these new features.

Another potential issue is that the collation support is (obviously) not available on MongoDB version < v3.4. It would be nice to throw an error if someone attempts to use the `collation` parameter with an older version of MongoDB. But... only a reference to the collection is passed to the service, which precludes checking the `db` version without hacking a reference to the parent `db` instance through the collection. I'm not a MongoDB ace–maybe there's a simple way to check the MongoDB version that I'm unaware of. 

## - Disclaimer -
I've implemented `collation` as a parameter because to me, that seems like the most natural way to use it. I'm relatively new to using Feathers... and I know one of the main selling points of using Feathers is the ability to "drop-in" other storage engines. So I'm not sure if there's a philosophical resistance to implementing database-specific features. It seems, however, that other database adapters do exactly that (KnexJS for example, [implements a special `$like` filter](https://docs.feathersjs.com/databases/knexjs.html)). If there's a more appropriate way of implementing this feature, please let me know. I'd be glad to modify the PR.