### PR TITLE
Allow setting the model later

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,6 @@ class Service {
       throw new Error('MongoDB options have to be provided');
     }
 
-    if (!options.Model) {
-      throw new Error('MongoDB collection `Model` needs to be provided');
-    }
-
     this.Model = options.Model;
     this.id = options.id || '_id';
     this.events = options.events || [];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,12 +47,6 @@ describe('Feathers MongoDB Service', () => {
       );
     });
 
-    describe('when missing a Model', () => {
-      it('throws an error', () =>
-        expect(service.bind(null, {})).to.throw('MongoDB collection `Model` needs to be provided')
-      );
-    });
-
     describe('when missing the id option', () => {
       it('sets the default to be _id', () =>
         expect(service({ Model: db }).id).to.equal('_id')


### PR DESCRIPTION
Since the MongoDB connection initialization happens asynchronously the easiest way of dealing with initializing a model is to allow setting it at a later point in time.