### PR TITLE
Coerce stringified ObjectIDs in find if present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,12 @@ class Service {
   _find (params, count, getFilter = filter) {
     // Start with finding all, and limit when necessary.
     let { filters, query } = getFilter(params.query || {});
+
+    // Objectify the id field if it's present
+    if (query[this.id]) {
+      query[this.id] = this._objectifyId(query[this.id]);
+    }
+
     let q = this.Model.find(query);
 
     if (filters.$select) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -160,6 +160,21 @@ describe('Feathers MongoDB Service', () => {
       });
     });
 
+    it('should coerce the id field to an objectId in find', () => {
+      return peopleService
+        .create({ name: 'Coerce' })
+        .then(r => {
+          return peopleService.find({
+            query: {
+              _id: r._id.toString()
+            }
+          });
+        })
+        .then(r => {
+          expect(r).to.have.lengthOf(1);
+        });
+    });
+
     it('sorts with default behavior without collation param', () => {
       return peopleService
         .find({ query: { $sort: {name: -1} } })


### PR DESCRIPTION
### Summary

Pretty much what it says on the tin - if the id field is present in a find's query we will attempt to coerce it to an ObjectID. The original motivation for use in the [populate](https://docs.feathersjs.com/api/hooks-common.html#populateoptions-object-hookfunc-source) hook, since populate uses find to resolve dependencies.

Thanks!